### PR TITLE
highlight calls to erlang modules as modules

### DIFF
--- a/lib/makeup/lexers/elixir_lexer.ex
+++ b/lib/makeup/lexers/elixir_lexer.ex
@@ -465,6 +465,18 @@ defmodule Makeup.Lexers.ElixirLexer do
     ]
   end
 
+  # When calling functions from an erlang module, highlight the atom as a module.
+  #
+  #     :crypto.strong_rand_bytes(4)
+  defp postprocess_helper([
+         {:string_symbol, attrs1, [":" | _] = module},
+         {:operator, _, "."} = op,
+         {:name, _, _} = text
+         | tokens
+       ]) do
+    [{:name_class, attrs1, module}, op, text | postprocess_helper(tokens)]
+  end
+
   defp postprocess_helper([{:name, attrs, text} | tokens]) when text in @keyword,
     do: [{:keyword, attrs, text} | postprocess_helper(tokens)]
 

--- a/test/makeup/lexers/elixir_lexer/elixir_lexer_tokenizer_test.exs
+++ b/test/makeup/lexers/elixir_lexer/elixir_lexer_tokenizer_test.exs
@@ -357,6 +357,17 @@ defmodule ElixirLexerTokenizerTestSnippet do
       assert lex(":...") === [{:string_symbol, %{}, ":..."}]
       assert lex(":%{}") === [{:string_symbol, %{}, ":%{}"}]
     end
+
+    test "atoms used as modules are highlighted as modules" do
+      assert lex(":crypto.strong_rand_bytes(4)") === [
+               {:name_class, %{}, ":crypto"},
+               {:operator, %{}, "."},
+               {:name, %{}, "strong_rand_bytes"},
+               {:punctuation, %{group_id: "group-1"}, "("},
+               {:number_integer, %{}, "4"},
+               {:punctuation, %{group_id: "group-1"}, ")"}
+             ]
+    end
   end
 
   describe "numbers" do


### PR DESCRIPTION
:wave: hiya!

Following up on https://github.com/elixir-lang/tree-sitter-elixir/pull/5#issuecomment-941556251:

This PR adds a post-processing step that transforms regular atoms to be modules (`:name_class`es) when they're part on the left-hand-side of a `.` operator, so a call of a function on an erlang module highlights the same as a call on an Elixir module.

I'm pretty new to the makeup_elixir codebase so this might not be the correct place to put this transformation. Let me know!

cc: @jonatanklosko 