### PR TITLE
Bug fix: prompts and stacktrace not lexed correctly if preceding line has trailing whitespace

### DIFF
--- a/lib/makeup/lexers/elixir_lexer.ex
+++ b/lib/makeup/lexers/elixir_lexer.ex
@@ -28,7 +28,8 @@ defmodule Makeup.Lexers.ElixirLexer do
   whitespace = ascii_string([?\r, ?\s, ?\n, ?\f], min: 1) |> token(:whitespace)
 
   newlines =
-    choice([string("\r\n"), string("\n")])
+    optional(ascii_string([?\s, ?\t, ?\r], min: 1))
+    |> choice([string("\r\n"), string("\n")])
     |> optional(ascii_string([?\s, ?\n, ?\f, ?\r], min: 1))
     |> token(:whitespace)
 

--- a/test/makeup/lexers/elixir_lexer/elixir_lexer_tokenizer_test.exs
+++ b/test/makeup/lexers/elixir_lexer/elixir_lexer_tokenizer_test.exs
@@ -143,6 +143,20 @@ defmodule ElixirLexerTokenizerTestSnippet do
                {:operator, %{}, ">"}
              ]
     end
+
+    test "iex prompt works when previous line has trailing whitespace" do
+      assert lex("x \niex> ") == [
+        {:name, %{}, "x"},
+        {:whitespace, %{}, " \n"},
+        {:generic_prompt, %{selectable: false}, "iex> "},
+      ]
+
+      assert lex("x \r\niex> ") == [
+        {:name, %{}, "x"},
+        {:whitespace, %{}, " \r\n"},
+        {:generic_prompt, %{selectable: false}, "iex> "},
+      ]
+    end
   end
 
   describe "def-like macros" do


### PR DESCRIPTION
I found a way to break the lexer such that `iex>` prompts and stacktraces don't get formatted correctly:

<img width="338" alt="Screenshot 2022-10-14 at 16 00 25" src="https://user-images.githubusercontent.com/85154056/195878878-9fda5b81-b7f4-4a5a-be09-9f3939a85d22.png">

<img width="187" alt="Screenshot 2022-10-14 at 16 00 42" src="https://user-images.githubusercontent.com/85154056/195878989-3eb97082-f5b3-421d-bd0a-753edfb26f54.png">

This error occurs when the prompt or stacktrace is immediately preceded by a line with trailing whitespace. I.e. the highlighted code in those screenshots is `"iex> 123\s\niex> 456"` and `raise "error"\s\n** (RuntimeError) error`. (Note the `\s`.)

Of course, perfect code wouldn't have trailing whitespace in the first place - but it's still syntactically valid and something that should be lexed in the normal way, like so:

<img width="281" alt="Screenshot 2022-10-14 at 16 05 15" src="https://user-images.githubusercontent.com/85154056/195879831-97366ed4-2551-41a5-b02b-3758905a5041.png">

This PR provides a fix.