### PR TITLE
allow to register custom lexers for sigils

### DIFF
--- a/test/makeup/lexers/elixir_lexer/elixir_lexer_tokenizer_test.exs
+++ b/test/makeup/lexers/elixir_lexer/elixir_lexer_tokenizer_test.exs
@@ -695,4 +695,22 @@ defmodule ElixirLexerTokenizerTestSnippet do
              {:punctuation, %{group_id: "group-1"}, "}"}
            ]
   end
+
+  describe "custom lexers for sigils" do
+    test "can register a custom lexer" do
+      defmodule MyCustomLexer do
+        def lex(input) do
+          [{:keyword, %{}, input}]
+        end
+      end
+
+      Makeup.Lexers.ElixirLexer.register_sigil_lexer("H", MyCustomLexer)
+
+      assert lex("~H|Hello, world!|") == [
+               {:string_sigil, %{}, "~H|"},
+               {:keyword, %{}, "Hello, world!"},
+               {:string_sigil, %{}, "|"}
+             ]
+    end
+  end
 end


### PR DESCRIPTION
This allows highlighting HEEx sigils using the HEExLexer, for example.