### PR TITLE
Handle newlines inside an IEx prompt

### DIFF
--- a/lib/makeup/lexers/elixir_lexer.ex
+++ b/lib/makeup/lexers/elixir_lexer.ex
@@ -520,6 +520,17 @@ defmodule Makeup.Lexers.ElixirLexer do
     [first, second | extra_tokens ++ [end_sigil | postprocess_helper(rest)]]
   end
 
+  # When parsing a ...> from a string we need to ensure that the newline is still selectable
+  defp postprocess_helper([
+         {:generic_prompt, %{language: :elixir} = meta, ["\n..." | rest_text]}
+         | rest
+       ]) do
+    newline = {:generic_prompt, %{language: :elixir, selectable: true}, ["\n"]}
+    # Remove the \n from the ...> prompt
+    first = {:generic_prompt, meta, ["..." | rest_text]}
+    [newline, first | postprocess_helper(rest)]
+  end
+
   defp postprocess_helper([{:string_sigil, attrs, content} | tokens]) do
     # content is a list of the format ["~", sigil_char, separator, ... sigil_content ..., end_separator]
     sigil =

--- a/test/makeup/lexers/elixir_lexer/elixir_lexer_tokenizer_test.exs
+++ b/test/makeup/lexers/elixir_lexer/elixir_lexer_tokenizer_test.exs
@@ -553,13 +553,17 @@ defmodule ElixirLexerTokenizerTestSnippet do
              {:operator, %{}, "="},
              {:whitespace, %{}, " "},
              {:string, %{}, "\""},
-             {:generic_prompt, %{selectable: false}, "\n...> "},
+             {:generic_prompt, %{selectable: true}, "\n"},
+             {:generic_prompt, %{selectable: false}, "...> "},
              {:string, %{}, "ine1"},
-             {:generic_prompt, %{selectable: false}, "\n...> "},
+             {:generic_prompt, %{selectable: true}, "\n"},
+             {:generic_prompt, %{selectable: false}, "...> "},
              {:string, %{}, "line2"},
-             {:generic_prompt, %{selectable: false}, "\n...> "},
+             {:generic_prompt, %{selectable: true}, "\n"},
+             {:generic_prompt, %{selectable: false}, "...> "},
              {:string, %{}, "ilne3"},
-             {:generic_prompt, %{selectable: false}, "\n...> "},
+             {:generic_prompt, %{selectable: true}, "\n"},
+             {:generic_prompt, %{selectable: false}, "...> "},
              {:string, %{}, "\""},
              {:whitespace, %{}, "\n"}
            ]
@@ -578,7 +582,7 @@ defmodule ElixirLexerTokenizerTestSnippet do
         '''
 
         first_prompt = "iex#{prompt_number}> "
-        other_prompt = "\n...#{prompt_number}> "
+        other_prompt = "...#{prompt_number}> "
 
         assert [
                  {:generic_prompt, %{selectable: false}, ^first_prompt},
@@ -587,12 +591,16 @@ defmodule ElixirLexerTokenizerTestSnippet do
                  {:operator, %{}, "="},
                  {:whitespace, %{}, " "},
                  {ttype, %{}, ^ldelim},
+                 {:generic_prompt, %{selectable: true}, "\n"},
                  {:generic_prompt, %{selectable: false}, ^other_prompt},
                  {ttype, %{}, "line1"},
+                 {:generic_prompt, %{selectable: true}, "\n"},
                  {:generic_prompt, %{selectable: false}, ^other_prompt},
                  {ttype, %{}, "line2"},
+                 {:generic_prompt, %{selectable: true}, "\n"},
                  {:generic_prompt, %{selectable: false}, ^other_prompt},
                  {ttype, %{}, "line3"},
+                 {:generic_prompt, %{selectable: true}, "\n"},
                  {:generic_prompt, %{selectable: false}, ^other_prompt},
                  {ttype, %{}, ^rdelim},
                  {:whitespace, %{}, "\n"}
@@ -618,7 +626,7 @@ defmodule ElixirLexerTokenizerTestSnippet do
           '''
 
           first_prompt = "iex#{prompt_number}> "
-          other_prompt = "\n...#{prompt_number}> "
+          other_prompt = "...#{prompt_number}> "
 
           sigil_start = sigil_prefix <> ldelim
 
@@ -629,12 +637,16 @@ defmodule ElixirLexerTokenizerTestSnippet do
                    {:operator, %{}, "="},
                    {:whitespace, %{}, " "},
                    {ttype, %{}, ^sigil_start},
+                   {:generic_prompt, %{selectable: true}, "\n"},
                    {:generic_prompt, %{selectable: false}, ^other_prompt},
                    {ttype, %{}, "line1"},
+                   {:generic_prompt, %{selectable: true}, "\n"},
                    {:generic_prompt, %{selectable: false}, ^other_prompt},
                    {ttype, %{}, "line2"},
+                   {:generic_prompt, %{selectable: true}, "\n"},
                    {:generic_prompt, %{selectable: false}, ^other_prompt},
                    {ttype, %{}, "line3"},
+                   {:generic_prompt, %{selectable: true}, "\n"},
                    {:generic_prompt, %{selectable: false}, ^other_prompt},
                    {ttype, %{}, ^rdelim},
                    {:whitespace, %{}, "\n"}


### PR DESCRIPTION
When given text like:
```
iex> existing_zipper = ("""
...> IO.inspect("Hello, world!")
...> IO.puts("abc")
...> """
```

We need to ensure that the newlines are preserved in the selectable text. With this PR ex_doc will allow us to copy the text:
```
existing_zipper = ("""
IO.inspect("Hello, world!")
IO.puts("abc")
"""
```
Without this PR, ex_doc copies the text:
```
existing_zipper = ("""IO.inspect("Hello, world!")IO.puts("abc")"""
```
and this breaks when pasted into iex with an error like:
```
** (SyntaxError) invalid syntax found on iex:1:23:
    error: heredoc allows only whitespace characters followed by a new line after opening """
```

Fixes https://github.com/elixir-lang/ex_doc/issues/2096