### PR TITLE
Don't treat continuation tokens of interpolated sigils as sigils

### DIFF
--- a/lib/makeup/lexers/elixir_lexer.ex
+++ b/lib/makeup/lexers/elixir_lexer.ex
@@ -531,8 +531,11 @@ defmodule Makeup.Lexers.ElixirLexer do
     [newline, first | postprocess_helper(rest)]
   end
 
-  defp postprocess_helper([{:string_sigil, attrs, content} | tokens]) do
-    # content is a list of the format ["~", sigil_char, separator, ... sigil_content ..., end_separator]
+  defp postprocess_helper([{:string_sigil, attrs, ["~" | _] = content} | tokens]) do
+    # content is a list of the format ["~", sigil_char, separator, ... sigil_content ..., end_separator].
+    # A sigil containing interpolation is split into multiple :string_sigil tokens,
+    # of which only the first starts with "~"; the rest are plain sigil content
+    # and fall through to the catch-all clause.
     sigil =
       content
       |> Enum.at(1)

--- a/test/makeup/lexers/elixir_lexer/elixir_lexer_sigil_lexer_test.exs
+++ b/test/makeup/lexers/elixir_lexer/elixir_lexer_sigil_lexer_test.exs
@@ -21,6 +21,29 @@ defmodule ElixirLexerSigilLexerTest do
       Application.put_env(:makeup_elixir, :sigil_lexers, %{})
     end
 
+    test "does not treat continuation tokens of interpolated sigils as sigils" do
+      defmodule PassthroughLexer do
+        def lex(input, opts) do
+          [{:keyword, %{opts: opts}, input}]
+        end
+      end
+
+      Makeup.Lexers.ElixirLexer.register_sigil_lexer("H", PassthroughLexer)
+
+      # A sigil containing interpolation is split into multiple :string_sigil
+      # tokens. The `H` at index 1 of the continuation token `/HEAD"` must not
+      # be mistaken for a ~H sigil.
+      assert lex(~S[~w"refs/remotes/#{remote}/HEAD"]) == [
+               {:string_sigil, %{}, "~w\"refs/remotes/"},
+               {:string_interpol, %{group_id: "group-1"}, "\#{"},
+               {:name, %{}, "remote"},
+               {:string_interpol, %{group_id: "group-1"}, "}"},
+               {:string_sigil, %{}, "/HEAD\""}
+             ]
+    after
+      Application.put_env(:makeup_elixir, :sigil_lexers, %{})
+    end
+
     test "does not lex inside iex prompts" do
       # does not exist, but should also not be invoked
       Makeup.Lexers.ElixirLexer.register_sigil_lexer("PY", DoesNotExist, foo: :bar)


### PR DESCRIPTION
A sigil containing interpolation is split into multiple `:string_sigil` tokens, one chunk before and one after each interpolation. The custom sigil lexer postprocessing matches any `:string_sigil` token, reads the element at index 1 to look up a registered sigil lexer, and then asserts the token starts with `"~"` — which only holds for the opening chunk.

If the element at index 1 of a later chunk happens to be a registered sigil character, the lookup succeeds and the assertion crashes with a `MatchError`. This happens in the wild: with makeup_eex registering a lexer for `~H`, lexing [credo's `first_run_hint.ex`](https://github.com/rrrene/credo/blob/v1.7.3/lib/credo/cli/output/first_run_hint.ex) crashes on

```elixir
~w"symbolic-ref refs/remotes/#{remote_name}/HEAD"
```

because the chunk after the interpolation is `/HEAD"`, whose element at index 1 is `H`:

```
** (MatchError) no match of right hand side value: [47, 72, 69, 65, 68, "\""]
```

The custom sigil clause now only matches tokens that start with `"~"`, so continuation chunks fall through to the catch-all clause and are kept as plain sigil content.